### PR TITLE
fix: added version number 0.9.0.0 such that dendro can be used on Sha…

### DIFF
--- a/DendroGH/DendroGHInfo.cs
+++ b/DendroGH/DendroGHInfo.cs
@@ -2,6 +2,8 @@
 using System.Drawing;
 using Grasshopper.Kernel;
 
+[assembly: Grasshopper.Kernel.GH_Loading(GH_LoadingDemand.ForceDirect)]
+
 namespace DendroGH
 {
     public class DendroGHInfo : GH_AssemblyInfo
@@ -50,6 +52,22 @@ namespace DendroGH
             {
                 //Return a string representing your preferred contact details.
                 return "dev@ecrlabs.com";
+            }
+        }
+        public override string Version
+        {
+            get
+            {
+                //Return a string representing the version.
+                return "0.9.0.0";
+            }
+        }
+        public override string AssemblyVersion
+        {
+            get
+            {
+                //Return a string representing the assembly version. Not sure what's the difference to Version, let's use always the same. 
+                return this.Version;
             }
         }
     }

--- a/DendroGH/Properties/AssemblyInfo.cs
+++ b/DendroGH/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("0.9.0.0")]
+[assembly: AssemblyFileVersion("0.9.0.0")]


### PR DESCRIPTION
The plugin didn't have version number settings corresponding to the version information on food4rhino. Added version 0.9.0.0 such that it gets included in Grasshopper files and can be reviewed. Please accept the pull request, which will enable this plugin to be used on ShapeDiver.